### PR TITLE
 feat(notifications): add unlink device support and FCM cleanup on lo…

### DIFF
--- a/App.js
+++ b/App.js
@@ -35,7 +35,6 @@ export default function App() {
   }, [colorScheme, theme]);
 
   useEffect(() => {
-    // ✅ Escucha notificaciones en primer plano
     const unsubscribe = onMessage(messaging, async remoteMessage => {
       Alert.alert('¡Nueva Notificación!', remoteMessage.notification?.body || 'Sin contenido');
     });

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -1,0 +1,72 @@
+import { Platform, PermissionsAndroid } from 'react-native';
+import { getApp } from '@react-native-firebase/app';
+import {
+    getMessaging,
+    getToken,
+    requestPermission,
+    deleteToken,
+    AuthorizationStatus,
+} from '@react-native-firebase/messaging';
+
+import {
+    saveFirebaseDeviceToken,
+    deleteFirebaseTokenOnServer,
+} from '../service/firebase.service';
+
+const messaging = getMessaging(getApp());
+
+const requestUserPermission = async () => {
+    if (Platform.OS === 'ios') {
+        const authStatus = await requestPermission(messaging);
+        return (
+            authStatus === AuthorizationStatus.AUTHORIZED ||
+            authStatus === AuthorizationStatus.PROVISIONAL
+        );
+    } else if (Platform.OS === 'android') {
+        try {
+            const result = await PermissionsAndroid.request(
+                PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
+            );
+            return result === PermissionsAndroid.RESULTS.GRANTED;
+        } catch (error) {
+            console.error('Fallo al solicitar permiso en Android', error);
+            return false;
+        }
+    }
+    return false;
+};
+
+export const useNotifications = () => {
+    const enableNotifications = async (onSuccess, onError) => {
+        try {
+            const granted = await requestUserPermission();
+            if (!granted) throw new Error('Permiso denegado');
+
+            const token = await getToken(messaging);
+            await saveFirebaseDeviceToken(token);
+
+            if (onSuccess) onSuccess();
+        } catch (err) {
+            console.error('Error en enableNotifications:', err);
+            if (onError) onError(err);
+        }
+    };
+
+    const disableNotifications = async (onSuccess, onError) => {
+        try {
+            const token = await getToken(messaging);
+            await deleteToken(messaging);
+            await deleteFirebaseTokenOnServer(token);
+
+            if (onSuccess) onSuccess();
+        } catch (err) {
+            console.error('Error en disableNotifications:', err);
+            if (onError) onError(err);
+        }
+    };
+
+    return {
+        enableNotifications,
+        disableNotifications,
+    };
+};

--- a/src/screens/tabs/ProfileScreen.js
+++ b/src/screens/tabs/ProfileScreen.js
@@ -8,10 +8,7 @@ import AuthorizedRoute from '../../components/AuthorizedRoute';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useTheme } from 'react-native-paper';
 import { info } from '../../service/user.service';
-
-// ✅ Import para eliminar el token FCM
-import { getMessaging, deleteToken } from '@react-native-firebase/messaging';
-import { getApp } from '@react-native-firebase/app';
+import { useNotifications } from '../../hooks/useNotifications'; // ✅
 
 const formatDate = date => {
   if (!date) return 'No disponible';
@@ -74,14 +71,14 @@ export default function ProfileScreen() {
   const router = useRouter();
   const theme = useTheme();
   const styles = getStyles(theme);
+  const { disableNotifications } = useNotifications(); // ✅
 
   const handleLogout = async () => {
     try {
-      // ✅ Eliminar token FCM localmente
-      const messaging = getMessaging(getApp());
-      await deleteToken(messaging);
-      console.log('[ProfileScreen] FCM token eliminado');
-
+      await disableNotifications(
+        () => console.log('[ProfileScreen] FCM token eliminado'),
+        (err) => console.warn('[ProfileScreen] No se pudo eliminar el token FCM:', err.message)
+      );
       await logout();
       router.replace('Auth');
     } catch (error) {
@@ -107,7 +104,6 @@ export default function ProfileScreen() {
 
   useEffect(() => {
     fetchUserInfo();
-    return () => { };
   }, []);
 
   const initials = `${userInfo?.firstname?.[0] ?? ''}${userInfo?.lastname?.[0] ?? ''}`.toUpperCase();

--- a/src/service/firebase.service.js
+++ b/src/service/firebase.service.js
@@ -2,7 +2,11 @@ import { AuthorizedService } from '../api/apiClient';
 
 const BASE_URL = '/v1/notification';
 
-export const saveFirebaseDeviceToken = async token => {
+/**
+ * Guarda (linkea) el token del dispositivo con el usuario autenticado.
+ * @param {string} token - Firebase Device Token (FCM).
+ */
+export const saveFirebaseDeviceToken = async (token) => {
   try {
     const response = await AuthorizedService.post(`${BASE_URL}/link-device`, {
       firebaseDeviceId: token,
@@ -10,6 +14,22 @@ export const saveFirebaseDeviceToken = async token => {
     return response.data;
   } catch (error) {
     console.error('[Firebase Service] Error saving Firebase device token:', error);
+    throw error;
+  }
+};
+
+/**
+ * Elimina (unlinkea) el token del dispositivo del backend.
+ * @param {string} token - Firebase Device Token (FCM) a desvincular.
+ */
+export const deleteFirebaseTokenOnServer = async (token) => {
+  try {
+    const response = await AuthorizedService.post(`${BASE_URL}/unlink-device`, {
+      firebaseDeviceId: token,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('[Firebase Service] Error deleting Firebase device token:', error);
     throw error;
   }
 };


### PR DESCRIPTION
…gout

- Implemented deleteFirebaseTokenOnServer to unlink FCM device token from backend
- Updated useNotifications hook to handle enable/disable notifications via FCM
- Ensured token deletion on logout in ProfileScreen
- Connected to backend endpoints /link-device and /unlink-device

Ready for testing across multiple devices with the same user